### PR TITLE
MIPS: Add support for VR9 chip version 1.2 on VGV7510KW22

### DIFF
--- a/board/arcadyan/vgv7510kw22/vgv7510kw22.c
+++ b/board/arcadyan/vgv7510kw22/vgv7510kw22.c
@@ -89,7 +89,10 @@ int board_eth_init(bd_t * bis)
 	const enum ltq_gphy_clk clk = LTQ_GPHY_CLK_25MHZ_PLL0;
 	const ulong fw_addr = 0x80FF0000;
 
-	ltq_gphy_phy22f_a1x_load(fw_addr);
+	if (ltq_chip_version_get() == 1)
+		ltq_gphy_phy22f_a1x_load(fw_addr);
+	else
+		ltq_gphy_phy22f_a2x_load(fw_addr);
 
 	ltq_cgu_gphy_clk_src(clk);
 


### PR DESCRIPTION
Most of the VGV7510KW22 boards I have seen are using a version 1.1 VR9.
However, there are newer boards out there which are shipped with a more
recent SoC revision.
As a side-note: The newer boards are shipped with brn-boot V1.08.1
instead of V1.07.

Signed-off-by: Martin Blumenstingl <martin.blumenstingl@googlemail.com>